### PR TITLE
Switch to yt-dlp, use RSS for IDs, drop jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,18 @@ Whole idea came from realizing that [sxiv](https://github.com/muennich/sxiv) in 
 you to select images the same way programs like rofi, dmenu, fzf, etc.
 This makes it usefull as some sort of dialog.
 Images contain *video id* in it's name so all you need is to play it via [mpv](https://github.com/mpv-player/mpv)
-through [youtube-dl](https://github.com/ytdl-org/youtube-dl).
+through [yt-dlp](https://github.com/yt-dlp/yt-dlp).
 Screenshot above has my modified fork of [sxiv](https://github.com/muennich/sxiv) so it looks little different.
 
 I rewrote this script with a lot of comments so feel free to fork and modify it to your liking
 
 # DEPENDENCIES
 
-This project has 4 dependencies and 3 optional ones. If you use arch or almost any normal linux distribution, this should be easy to get for you.
+This project has 3 dependencies and 2 optional ones. If you use arch or almost any normal linux distribution, this should be easy to get for you.
 
 * [sxiv](https://github.com/muennich/sxiv) or [nsxiv](https://github.com/nsxiv/nsxiv)
-* [youtube-dl](https://github.com/ytdl-org/youtube-dl)
+* [yt-dlp](https://github.com/yt-dlp/yt-dlp)
 * [mpv](https://github.com/mpv-player/mpv)
-* [jq](https://github.com/stedolan/jq)
 * ===
 * [dunst](https://github.com/dunst-project/dunst)
 * [xob](https://github.com/florentc/xob)
@@ -63,28 +62,18 @@ Without this dependency you wouldnt see any notifications, but it would still wo
 Script was rewritten to avoid bash dependency.
 Use any POSIX compliant shell to run (like *dash* but *bash* will also suffice).
 
-## Optional change
-Recently, `youtube-dl` appears to be pretty slow.
-As I have no idea why this would be the case, I leave this as default still.
-If your buffering is slow, you should try `youtube-dl` alternative: [yt-dlp](https://github.com/yt-dlp/yt-dlp#installation).
-You need to tell mpv to use it via mpv's configuration file (`$XDG_CONFIG_HOME/mpv/mpv.conf`).
-Add this line to said file to switch (for me this one is WAY FASTER).
-```
-script-opts=ytdl_hook-ytdl_path=yt-dlp
-```
-
 ## ARCH
 on arch based distro, you can skip getting dependencies and install via [AUR](https://aur.archlinux.org/packages/subtube-git/) in [install section](#install).
 ```
-sudo pacman -S sxiv mpv dunst youtube-dl jq
+sudo pacman -S sxiv mpv dunst yt-dlp
 paru xob
 ```
 
 ## DEBIAN/UBUNTU
 
 ```
-pip install --user youtube-dl
-sudo apt install sxiv mpv dunst jq
+pip install --user yt-dlp
+sudo apt install sxiv mpv dunst
 ```
 Xob is not present on debian repo, install from source via link in *dependencies*. You will probably just need to run these commands
 
@@ -97,9 +86,9 @@ sudo make install
 ```
 
 # UPDATE
-if script stops working one day for you, you need to update your youtube-dl
+if script stops working one day for you, you need to update your yt-dlp
 ```
-pip install --user --update youtube-dl
+pip install --user --update yt-dlp
 ```
 
 
@@ -186,11 +175,9 @@ subtube play -h "firefox --headless"
 to play with custom handler. Each handler call wont block execution (ran in background).
 
 ### add
-adds new subscribed channel.
-This is link of channel's videos page (we parse that page so it needs to be videos tab)
-
+adds new subscribed channel. This is a link of a channel's page.
 ```
-subtube add "https://www.youtube.com/channel/UCYO_jab_esuFRV4b17AJtAw/videos"
+subtube add "https://www.youtube.com/@3blue1brown"
 ```
 
 ### clean

--- a/subtube
+++ b/subtube
@@ -84,25 +84,14 @@ update(){
         # notify progress
         [ "$1" != "secret" ] && progress_bar $sub_i "$subcount" 30
 
-        # get first 10 video hashes parsed from youtube video page
-        vid_ids=$(curl -s "$line" \
-            | grep ytInitialData \
-            | head -n 1 \
-            | sed 's/;$// ; s/window\["ytInitialData"\]\s*=\s*// ; s/.*var ytInitialData = //' \
-            | jq -r ".contents\
-            .twoColumnBrowseResultsRenderer\
-            .tabs[1]\
-            .tabRenderer\
-            .content\
-            .sectionListRenderer\
-            .contents[0]\
-            .itemSectionRenderer\
-            .contents[0]\
-            .gridRenderer\
-            .items\
-            | .[].gridVideoRenderer.videoId" \
-            2> /dev/null \
-            | head)
+		channel_id="$(yt-dlp --playlist-items 0 -O playlist:channel_url "$line" \
+			| awk -F '/' '{print $5}' 2> /dev/null)"
+
+        # get recent video hashes parsed from youtube channel RSS page
+		vid_ids="$(curl -s "https://www.youtube.com/feeds/videos.xml?channel_id=$channel_id" \
+			| grep "<yt:videoId>" \
+			| sed "s/<[^>]*>//g" \
+			| awk '{$1=$1};1' 2> /dev/null)"
 
         # loop over hashes
         echo "$vid_ids" | while read -r vid_id; do
@@ -245,14 +234,14 @@ get_title(){
     cache=$(check_cache_metadata "$1" title)
     [ "$cache" != "" ] \
         && echo "$cache" \
-        || youtube-dl -e "https://www.youtube.com/watch?v=$1"
+        || yt-dlp -e "https://www.youtube.com/watch?v=$1"
 }
 
 get_duration(){
     cache=$(check_cache_metadata "$1" duration)
     [ "$cache" != "" ] \
         && echo "$cache" \
-        || youtube-dl --get-duration "https://www.youtube.com/watch?v=$1"
+        || yt-dlp --get-duration "https://www.youtube.com/watch?v=$1"
 }
 
 check_cache_metadata(){


### PR DESCRIPTION
This commit drops support for youtube-dl so that channel IDs can be found with yt-dlp specific features. This is then used for obtaining a channels RSS feed ([eg.](https://www.youtube.com/feeds/videos.xml?channel_id=UC2eYFnH61tmytImy1mTYvhA)), which contains recent channel video IDs.

This is better than scraping the /videos page of a channel due to the unstable nature of scraping since a page layout rework will require a rework of this project. RSS, however, is much easier to parse and much less likely to have its layout modified in the future by Youtube.